### PR TITLE
Make this project usable via Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 \#*
 .idea
 .fuse*
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ php:
   - 5.6
   - hhvm
 
+before_script:
+  - composer install --prefer-source
+
 script: php run_tests.php

--- a/README.md
+++ b/README.md
@@ -8,6 +8,31 @@ Implements IETF JSON-patch (RFC 6902) and JSON-pointer (RFC 6901):
 http://tools.ietf.org/html/rfc6902
 http://tools.ietf.org/html/rfc6901
 
+Using with Composer
+-------------------
+
+To use this library as a Composer dependency in your project, include the
+following sections in your project's `composer.json` file:
+
+```
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/mikemccabe/json-patch-php"
+        }
+    ],
+    "require": {
+        "mikemccabe/json-patch-php": "dev-master"
+    }
+```
+
+Then, in your project's code, use the `JsonPatch` class definition from
+the `mikemccabe\JsonPatch` namespace like so:
+
+```php
+use mikemccabe\JsonPatch\JsonPatch;
+```
+
 Entry points
 ------------
 

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,10 @@
   "name": "mikemccabe/json-patch-php",
   "description": "Produce and apply json-patch objects",
   "type": "library",
-  "license": "LGPL-3.0"
+  "license": "LGPL-3.0",
+  "autoload": {
+      "psr-4": {
+          "mikemccabe\\JsonPatch\\": "src"
+      }
+  }
 }

--- a/run_tests.php
+++ b/run_tests.php
@@ -3,7 +3,9 @@
 // This is a simple jig for testing JsonPatch.inc against json-encoded
 // test files.
 
-require_once('JsonPatch.inc');
+require 'vendor/autoload.php';
+
+use mikemccabe\JsonPatch\JsonPatch;
 
 $verbose = false;
 

--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -56,7 +56,7 @@ scalars on return from patch().
 
 namespace JsonPatch;
 
-class JsonPatchException extends Exception { }
+class JsonPatchException extends \Exception { }
 
 
 class JsonPatch

--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -54,6 +54,7 @@ scalars on return from patch().
 
 */
 
+namespace JsonPatch;
 
 class JsonPatchException extends Exception { }
 

--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -54,7 +54,7 @@ scalars on return from patch().
 
 */
 
-namespace JsonPatch;
+namespace mikemccabe\JsonPatch;
 
 class JsonPatchException extends \Exception { }
 


### PR DESCRIPTION
Hi @mikemccabe,

Thank you for creating this project. We would like to use it as a Composer-installable package dependency in our project, https://packagist.org/packages/rackspace/php-opencloud. That would, however, require making a couple of changes to your project. Specifically:
* Adding a namespace to the source file, and
* Adding an autoloader declaration to composer.json.

This pull request introduces these changes.

If you merge this PR, any project could use your project as a Composer-installable package dependency by adding the following sections to _their_ composer.json:

```
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/mikemccabe/json-patch-php"
        }
    ],
    "require": {
        "mikemccabe/json-patch-php": "dev-master"
    }
```

Merging this PR will also make it easy for you to publish your package to [Packagist](https://packagist.org/), if you decide to do that in the future.