### PR TITLE
Fixed Array Diff

### DIFF
--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -346,8 +346,13 @@ class JsonPatch
       }
       else if ($i < $ldst && array_key_exists($i, $dst))
       {
-        $result[] = array("op" => "add", "path" => "$path/$i",
-                          "value" => $dst[$i]);
+          //-- Add operations need to moved to the front?
+          $operation  = array(
+              "op"    => "add",
+              "path"  => "$path/$i",
+              "value" => $dst[$i]
+          );
+          array_unshift($result, $operation);
       }
       else if ($i < $lsrc && !array_key_exists($i, $dst))
       {
@@ -356,7 +361,7 @@ class JsonPatch
       $i--;
     }
 
-    return array_reverse($result);
+    return $result;
   }
 
 

--- a/src/JsonPatch.php
+++ b/src/JsonPatch.php
@@ -355,7 +355,8 @@ class JsonPatch
       }
       $i--;
     }
-    return $result;
+
+    return array_reverse($result);
   }
 
 


### PR DESCRIPTION
Fix array diff issue, as positioning is not preserved, its generated in reverse breaking JSON-Patch 4.1 ADD: "The specified index MUST NOT be greater than the number of elements in the array."